### PR TITLE
Adjustments to widget template

### DIFF
--- a/inc/wp-core-contributions-widget-template.php
+++ b/inc/wp-core-contributions-widget-template.php
@@ -4,19 +4,15 @@
  *
  * @since     0.2
  */
-
-if ( ! defined( 'WP_CORE_CONTRIBUTIONS_WIDGET_DIR' ) ) exit;
-
-$out .= '<ul>';
-
-foreach ($items as $item) {
-	$out .= '<li>';
-
-	$out .= '<a href="' . $item['link'] . '">[' . $item['changeset'] . ']</a> ';
-	$out .= 'for <a href="http://core.trac.wordpress.org/ticket/' . $item['ticket'] . '">#' . $item['ticket'] . '</a>';
-
-	$out .= '</li>';
-}
-
-$out .= '</ul>';
 ?>
+
+<?php if ( isset( $items ) ) : ?>
+	<ul>
+	<?php foreach ( (array) $items as $item ) : ?>
+		<li><?php printf( __( '[%1$s] for %2$s' ),
+			'<a href="' . esc_url( $item['link'] ) . '">' . esc_html( $item['changeset'] ) . '</a>',
+			'<a href="' . esc_url( 'http://core.trac.wordpress.org/ticket/' . $item['ticket'] ) . '">' . esc_html( '#' . $item['ticket'] ) . '</a>'
+		); ?></li>
+	<?php endforeach; ?>
+	</ul>
+<?php endif; ?>

--- a/lib/class.wp-core-contributions-widget.php
+++ b/lib/class.wp-core-contributions-widget.php
@@ -50,7 +50,6 @@ class WP_Core_Contributions_Widget extends WP_Widget {
 
 		// Widget content
 		$items = WP_Core_Contributions::get_items($user);
-		$out = '';
 
 		// Include template - can be overriden by a theme!
 		$template_name = 'wp-core-contributions-widget-template.php';
@@ -60,8 +59,6 @@ class WP_Core_Contributions_Widget extends WP_Widget {
 		}
 
 		include_once( $path ); // This include will generate the markup for the widget
-
-		echo $out; // Echo the markup to the browser
 
 		echo $after_widget;
 	}


### PR DESCRIPTION
- Use WordPress "template" style for the widget template.
- Escape all date before printing to the screen.
- Update i18n to reflect entire sentence.
