### PR TITLE
Fixes issue #7: Updating plugin could remove user's own widget templates

### DIFF
--- a/wp-core-contributions-widget.php
+++ b/wp-core-contributions-widget.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Core Contributions Widget
 Plugin URI: http://jumping-duck.com/wordpress
 Description: Add a list of your accepted contributions to WordPress Core as a sidebar widget.
-Version: 1.2.2
+Version: 1.2.3
 Author: Eric Mann
 Author URI: http://eamann.com
 License: GPLv2+
@@ -26,13 +26,18 @@ License: GPLv2+
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-define( 'WP_CORE_CONTRIBUTIONS_WIDGET_VERSION', '1.0' );
+define( 'WP_CORE_CONTRIBUTIONS_WIDGET_VERSION', '1.2.3' );
 define( 'WP_CORE_CONTRIBUTIONS_WIDGET_URL',     plugin_dir_url( __FILE__ ) );
 define( 'WP_CORE_CONTRIBUTIONS_WIDGET_DIR',     dirname( __FILE__ ) . '/' );
 
-require_once( 'lib/class.wp-core-contributions.php' );
-require_once( 'lib/class.wp-core-contributions-widget.php' );
-require_once( 'lib/class.wp-codex-contributions-widget.php' );
+// Load widget templates automatically from /lib/ folder
+if ( is_dir( dirname(__FILE__) . '/lib/') ) {
+    $widgets = glob( WP_CORE_CONTRIBUTIONS_WIDGET_DIR . 'lib/class.*.php');
+    
+    foreach ( (array)$widgets as $widget ) {
+	include_once($widget);
+    }
+}
 
 WP_Core_Contributions::init();
 ?>


### PR DESCRIPTION
Before:
Widget templates loaded in the plugin's main file 'wp-core-contributions-widget.php' were specified manually. If someone specified a new widget template file in that main file & then upgraded the plugin, then their own template would be "lost" until they re-edit the main file again.

After:
We loop though all files in the /lib/ folder named 'class.*.php' and load them automatically

Results:
No need to modify 'wp-core-contributions-widget.php,' just name the new template files like 'class.*.php'
