### PR TITLE
Fixes issue #7: Updating plugin could remove user's own widget templates

### DIFF
--- a/wp-core-contributions-widget.php
+++ b/wp-core-contributions-widget.php
@@ -32,7 +32,7 @@ define( 'WP_CORE_CONTRIBUTIONS_WIDGET_DIR',     dirname( __FILE__ ) . '/' );
 
 // Load widget templates automatically from /lib/ folder
 if ( is_dir( dirname(__FILE__) . '/lib/') ) {
-    $widgets = glob( WP_CORE_CONTRIBUTIONS_WIDGET_DIR . 'lib/class.*.php');
+    $widgets = glob( WP_CORE_CONTRIBUTIONS_WIDGET_DIR . 'lib/class.*.php' );
     
     foreach ( (array)$widgets as $widget ) {
 	include_once($widget);


### PR DESCRIPTION
Before:
Widget templates loaded in the plugin's main file 'wp-core-contributions-widget.php' were specified manually. If someone specified a new widget template file in that main file & then upgraded the plugin, then their own template would be "lost" until they re-edit the main file again.

After:
We loop though all files in the /lib/ folder named 'class.*.php' and load them automatically

Results:
No need to modify 'wp-core-contributions-widget.php,' just name the new template files like 'class.*.php'
