### PR TITLE
Let's give the Widget forms a bit more room.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-/.idea
+/.project
+/.gitignore
+/.buildpath
+/.settings

--- a/lib/class.wp-codex-contributions-widget.php
+++ b/lib/class.wp-codex-contributions-widget.php
@@ -36,10 +36,12 @@ class WP_Codex_Contributions_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'wp-core-contributions-widget' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>" />
-
+		</p>
+		<p>
 			<label for="<?php echo $this->get_field_id( 'codex-user' ); ?>"><?php _e( 'Codex Username:', 'wp-core-contributions-widget' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'codex-user' ); ?>" name="<?php echo $this->get_field_name( 'codex-user' ); ?>" type="text" value="<?php echo $codex_user; ?>" />
-
+		</p>
+		<p>
 			<label for="<?php echo $this->get_field_id( 'display-count' ); ?>"><?php _e( 'Display How Many Changes?', 'wp-core-contributions-widget' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'display-count' ); ?>" name="<?php echo $this->get_field_name( 'display-count' ); ?>" type="text" value="<?php echo $codex_count; ?>" />
 		</p>

--- a/lib/class.wp-core-contributions-widget.php
+++ b/lib/class.wp-core-contributions-widget.php
@@ -36,10 +36,12 @@ class WP_Core_Contributions_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'wp-core-contributions-widget' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>" />
-
+		</p>
+		<p>
 			<label for="<?php echo $this->get_field_id( 'trac-user' ); ?>"><?php _e( 'Trac Username:', 'wp-core-contributions-widget' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('trac-user'); ?>" name="<?php echo $this->get_field_name( 'trac-user' ); ?>" type="text" value="<?php echo $trac_user; ?>" />
-
+		</p>
+		<p>
 			<label for="<?php echo $this->get_field_id( 'display-count' ); ?>"><?php _e( 'Display How Many Tickets?', 'wp-core-contributions-widget' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'display-count' ); ?>" name="<?php echo $this->get_field_name( 'display-count' ); ?>" type="text" value="<?php echo $trac_count; ?>" />
 		</p>


### PR DESCRIPTION
Default behavior is to have each form field in its own paragraph.

I don't know about the <code>.gitignore</code> issue, I thought I had it ignored...
