### PR TITLE
Fix codex feeds to use JSON

### DIFF
--- a/lib/class.wp-core-contributions.php
+++ b/lib/class.wp-core-contributions.php
@@ -78,7 +78,7 @@ class WP_Core_Contributions {
 	public static function get_codex_items( $username, $limit = 10 ) {
 		if ( null == $username ) return array();
 
-		if ( true || false == ( $formatted = get_transient( 'wp-codex-contributions-' . $username ) ) ) {
+		if ( false == ( $formatted = get_transient( 'wp-codex-contributions-' . $username ) ) ) {
 			$results_url = add_query_arg( array(
 				'action'    => 'query',
 				'list'      => 'usercontribs',


### PR DESCRIPTION
Not sure if there was a reason to choose serialized data and XML for the codex feeds. This pull request changes both codex methods to use JSON. I did update the intending for arrays too.
